### PR TITLE
Support for different monitor resolutions

### DIFF
--- a/LiveWallpaper/DrawingHelpers.cpp
+++ b/LiveWallpaper/DrawingHelpers.cpp
@@ -2,8 +2,8 @@
 
 point GetScreenSize() {
 	return {
-		GetSystemMetrics(SM_CXSCREEN),
-		GetSystemMetrics(SM_CYSCREEN)
+		GetSystemMetricsForDpi(SM_CXSCREEN, 96),
+		GetSystemMetricsForDpi(SM_CYSCREEN, 96)
 	};
 }
 

--- a/LiveWallpaper/main.cpp
+++ b/LiveWallpaper/main.cpp
@@ -73,6 +73,8 @@ void SpawnRenderer() {
 // For some reason Windows thinks this is a reasonable entry point
 int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE, PWSTR, int) {
 
+	SetProcessDPIAware();
+
 	// Initialises stuff for a static window class, an object isn't actually created.
 	Window::MakeWindow(hInstance);
 


### PR DESCRIPTION
I had a 4K monitor and I had issues with LiveWallpaper. Now it supports not only FHD but also all other monitors with different resolutions.